### PR TITLE
Get working on PDN 4.3 + .NET 5

### DIFF
--- a/ComputeShaderEffects/ComputeShaderBase.cs
+++ b/ComputeShaderEffects/ComputeShaderBase.cs
@@ -41,7 +41,7 @@ namespace ComputeShaderEffects
         public bool CustomRegionHandling { get; set; }
 
         protected ComputeShaderBase(string name, Image image, string subMenuName, PaintDotNet.Effects.EffectFlags flags)
-            : base(name, image, subMenuName, flags)
+            : base(name, image, subMenuName, new EffectOptions() { Flags = flags })
         {
             MaxTextureSize = 8216;
             CustomRegionHandling = false;
@@ -351,7 +351,7 @@ namespace ComputeShaderEffects
                     if (_newRender)
                     {
                         _newRender = false;
-                        OnRenderRegion(SliceRectangles(new Rectangle[] { EnvironmentParameters.GetSelection(SrcArgs.Bounds).GetBoundsInt() }), DstArgs, SrcArgs);
+                        OnRenderRegion(SliceRectangles(new Rectangle[] { EnvironmentParameters.SelectionBounds }), DstArgs, SrcArgs);
                     }
                 }
                 else
@@ -441,7 +441,7 @@ namespace ComputeShaderEffects
 
         internal bool FullImageSelected(Rectangle bounds)
         {
-            Rectangle[] rois = EnvironmentParameters.GetSelection(bounds).GetRegionScansReadOnlyInt();
+            Rectangle[] rois = EnvironmentParameters.GetSelectionAsPdnRegion().GetRegionScansReadOnlyInt();
             return (rois.Length == 1 && rois[0] == bounds);
         }
 

--- a/ComputeShaderEffects/ComputeShaderEffects.csproj
+++ b/ComputeShaderEffects/ComputeShaderEffects.csproj
@@ -1,24 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{3B84F257-939F-4265-BFE0-453EA764D501}</ProjectGuid>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ComputeShaderEffects</RootNamespace>
-    <AssemblyName>ComputeShaderEffects</AssemblyName>
-    <StartupObject>
-    </StartupObject>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>2.0</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <StartupObject></StartupObject>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -34,111 +18,70 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>c:\Program Files\Paint.NET\Effects\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseVSHostingProcess>true</UseVSHostingProcess>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>c:\Program Files\Paint.NET\Effects\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisLogFile>..\..\..\..\Program Files\Paint.NET\Effects\ComputeShaderEffects.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisLogFile>..\..\..\Program Files\Paint.NET\Effects\ComputeShaderEffects.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
     <CodeAnalysisLogFile>..\..\..\..\Program Files\Paint.NET\Effects\ComputeShaderEffects.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
     <CodeAnalysisLogFile>..\..\..\Program Files\Paint.NET\Effects\ComputeShaderEffects.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
   <ItemGroup>
     <Reference Include="PaintDotNet.Base">
       <HintPath>C:\Program Files\paint.net\PaintDotNet.Base.dll</HintPath>
@@ -152,79 +95,13 @@
       <HintPath>C:\Program Files\paint.net\PaintDotNet.Effects.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SharpDX, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.4.0.1\lib\net45\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.D3DCompiler, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.D3DCompiler.4.0.1\lib\net45\SharpDX.D3DCompiler.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct3D11.4.0.1\lib\net45\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DXGI.4.0.1\lib\net45\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ComputeShaderBase.cs" />
-    <Compile Include="ChannelBlur\ChannelBlurGPU.cs" />
-    <Compile Include="IDisposableExtensions.cs" />
-    <Compile Include="ImageComputeShaderBase.cs" />
-    <Compile Include="RadialBlur\RadialBlurGPU.cs" />
-    <Compile Include="TiledComputeShaderBase.cs" />
-    <Compile Include="ZoomBlur\ZoomBlurGPU.cs" />
-    <Compile Include="DualPassComputeShaderBase.cs" />
-    <Compile Include="GaussianBlur\GaussianBlurGPU.cs" />
-    <Compile Include="MotionBlur\MotionBlurGPU.cs" />
-    <Compile Include="PluginSupportInfo.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
     <EmbeddedResource Include="Shaders\GaussianBlurHoriz.fx" />
     <EmbeddedResource Include="Shaders\GaussianBlurVert.fx" />
-    <None Include="ChannelBlur\ChannelBlur.hlsl" />
-    <None Include="ChannelBlur\ChannelBlurCompile.cmd" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="RadialBlur\RadialBlurBuff.hlsl" />
-    <None Include="RadialBlur\RadialBlur.hlsl" />
-    <None Include="RadialBlur\RadialBlurCompile.cmd" />
     <EmbeddedResource Include="Shaders\ZoomBlurBuff.fx" />
     <EmbeddedResource Include="Shaders\RadialBlurBuff.fx" />
-    <None Include="ZoomBlur\ZoomBlurBuff.hlsl" />
-    <None Include="ZoomBlur\ZoomBlur.hlsl" />
-    <None Include="ZoomBlur\ZoomBlurCompile.cmd" />
-    <None Include="GaussianBlur\GaussianBlur.hlsl" />
-    <None Include="GaussianBlur\GaussianBlurCompile.cmd" />
-    <None Include="MotionBlur\MotionBlurCompile.cmd" />
     <EmbeddedResource Include="Shaders\MotionBlur.fx" />
-    <None Include="MotionBlur\MotionBlur.hlsl" />
     <EmbeddedResource Include="Shaders\ChannelBlurHoriz.fx" />
     <EmbeddedResource Include="Shaders\ChannelBlurVert.fx" />
     <EmbeddedResource Include="Shaders\GaussianBlurHorizClamp.fx" />
@@ -249,5 +126,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="GaussianBlur\GaussianBlurIcon.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SharpDX" Version="4.0.1" />
+    <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" />
+    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" />
   </ItemGroup>
 </Project>

--- a/ComputeShaderEffects/DualPassComputeShaderBase.cs
+++ b/ComputeShaderEffects/DualPassComputeShaderBase.cs
@@ -117,7 +117,7 @@ namespace ComputeShaderEffects
 
                 for (int y = copyRect.Top; y < copyRect.Bottom; y++)
                 {
-                    CopyMemory(dest.GetPointPointer(copyRect.Left, y), source.GetPointPointer(copyRect.Left, y), length);
+                    BufferUtil.Copy(dest.GetPointPointer(copyRect.Left, y), source.GetPointPointer(copyRect.Left, y), length);
                 }
             }
         }

--- a/ComputeShaderEffects/DualPassComputeShaderBase.cs
+++ b/ComputeShaderEffects/DualPassComputeShaderBase.cs
@@ -40,7 +40,7 @@ namespace ComputeShaderEffects
             }
             else
             {
-                boundingTile = EnvironmentParameters.GetSelection(dstArgs.Bounds).GetBoundsInt();
+                boundingTile = EnvironmentParameters.SelectionBounds;
                 boundingTile.Inflate(ApronSize, ApronSize);
                 boundingTile.Intersect(dstArgs.Bounds);
             }
@@ -59,7 +59,7 @@ namespace ComputeShaderEffects
 
             if (Passes == 1)
             {
-                CopyRois(EnvironmentParameters.GetSelection(dstArgs.Bounds).GetRegionScansInt(),
+                CopyRois(EnvironmentParameters.GetSelectionAsPdnRegion().GetRegionScansReadOnlyInt(),
                     dstArgs.Surface,
                     surfaceCopy);
                 surfaceCopy.Dispose();
@@ -94,7 +94,7 @@ namespace ComputeShaderEffects
                     OnRenderRegion(rois, currentDestinationArgs, currentSourceArgs);
                     surfaceCopy.Dispose();
 
-                    CopyRois(EnvironmentParameters.GetSelection(dstArgs.Bounds).GetRegionScansInt(),
+                    CopyRois(EnvironmentParameters.GetSelectionAsPdnRegion().GetRegionScansReadOnlyInt(),
                         dstArgs.Surface,
                         surfaceCopy2);
 

--- a/ComputeShaderEffects/Properties/AssemblyInfo.cs
+++ b/ComputeShaderEffects/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -31,3 +32,5 @@ using System.Runtime.InteropServices;
 //
 [assembly: AssemblyVersion("3.1.0.0")]
 [assembly: AssemblyFileVersion("3.1.0.0")]
+
+[assembly: SupportedOSPlatform("windows")]

--- a/ComputeShaderEffects/TiledComputeShaderBase.cs
+++ b/ComputeShaderEffects/TiledComputeShaderBase.cs
@@ -37,7 +37,7 @@ namespace ComputeShaderEffects
             base.OnPreRender(dstArgs, srcArgs);
         }
 
-        protected override void OnRenderRegion(Rectangle[] rois, RenderArgs dstArgs, RenderArgs srcArgs)
+        protected override unsafe void OnRenderRegion(Rectangle[] rois, RenderArgs dstArgs, RenderArgs srcArgs)
         {
             Surface dst;
             Surface src;
@@ -90,7 +90,7 @@ namespace ComputeShaderEffects
                 // Copy tile from src to texture
                 SharpDX.DataBox dbox = Context.MapSubresource(textureTile, 0, MapMode.WriteDiscard, MapFlags.None);
                 IntPtr textureBuffer = dbox.DataPointer;
-                IntPtr srcPointer = src.GetPointPointer(tileRect.Left, tileRect.Top);
+                ColorBgra* srcPointer = src.GetPointPointer(tileRect.Left, tileRect.Top);
                 int length = tileRect.Width * s_BuffSize;
                 int sourceStride = src.Stride;
                 int dstStride = dbox.RowPitch;
@@ -98,9 +98,9 @@ namespace ComputeShaderEffects
 
                 for (int y = tileRect.Top; y < tileBottom; y++)
                 {
-                    CopyMemory(textureBuffer, srcPointer, length);
+                    BufferUtil.Copy((void*)textureBuffer, srcPointer, length);
                     textureBuffer = IntPtr.Add(textureBuffer, dstStride);
-                    srcPointer = IntPtr.Add(srcPointer, sourceStride);
+                    srcPointer = (ColorBgra*)((byte*)srcPointer + sourceStride);
                 }
                 Context.UnmapSubresource(textureTile, 0);
 


### PR DESCRIPTION
I've gotten this to build but I haven't tried it out yet . There were a few things that had to be changed to make it work w/ PDN 4.3 + .NET 5, so you'll need to release an update.

The `GetPointPointer` stuff will not work without the commits I just made (over in the PDN repository). I changed some of those methods around and ComputeShaderEffects was the only plugin I could find that was affected.